### PR TITLE
FEAT: fix resource manager crash

### DIFF
--- a/core/app/App.cpp
+++ b/core/app/App.cpp
@@ -27,7 +27,7 @@ Application::~Application()
 // Main game loop
 void Application::Execute()
 {
-  auto manager = game::manager::ResourceManager::GetInstance("../game/resources");
+  auto manager = game::manager::ResourceManager::GetInstance("..\\game\\resources");
 
   while (!_window.ShouldClose())    // Detect window close button
   {

--- a/core/gui/images/images.cpp
+++ b/core/gui/images/images.cpp
@@ -11,13 +11,21 @@ CImage::CImage(std::string image_path, raylib::Vector2 position, raylib::Vector2
     _rectangle.SetPosition(_position);
     _rectangle.SetSize(_size);
 
-    _image = std::make_shared<raylib::Texture2D>(GetWorkingDirectory() + _image_path);//.Load(_image_path);
+    _image = raylib::Texture2D(GetWorkingDirectory() + _image_path);
     
 };
 
 CImage::CImage(raylib::Texture2D* image, raylib::Vector2 position, raylib::Vector2 size)
 {
-    _image.reset(image);
+    _position = position;
+    _size = size;
+
+    if(image == nullptr) 
+    {
+        return;
+    }
+    
+    _image.Load(*image);
 
     _rectangle.SetPosition(_position);
     _rectangle.SetSize(_size);   
@@ -27,5 +35,5 @@ CImage::~CImage() { };
 
 void CImage::Draw()
 {
-    _image->Draw(raylib::Rectangle(0, 0, _image->GetWidth(), _image->GetHeight()) ,_rectangle);
+    _image.Draw(raylib::Rectangle(0, 0, _image.GetWidth(), _image.GetHeight()) ,_rectangle);
 };

--- a/core/gui/images/images.hpp
+++ b/core/gui/images/images.hpp
@@ -19,7 +19,7 @@ namespace core {
 
             private:
                 std::string _image_path;
-                std::shared_ptr<raylib::Texture2D> _image;
+                raylib::Texture2D _image;
                 raylib::Vector2 _position;
                 raylib::Vector2 _size;
                 raylib::Rectangle _rectangle;

--- a/game/managers/resource_manager.cpp
+++ b/game/managers/resource_manager.cpp
@@ -13,10 +13,7 @@ ResourceManager::ResourceManager(const std::string& dir) : _directory(dir)
 void ResourceManager::UpdateFileList()
 {
     _currentFiles.clear();
-    for (const auto& entry : std::filesystem::directory_iterator(_directory))
-    {
-        _currentFiles.insert(entry.path().string());
-    }
+    RecursiveScanDirectory(_directory, _currentFiles);
 };
 
 void ResourceManager::StartPeriodicCheck() {
@@ -26,10 +23,7 @@ void ResourceManager::StartPeriodicCheck() {
             std::this_thread::sleep_for(std::chrono::seconds(1));
 
             std::set<std::string> newFiles;
-            for (const auto& entry : std::filesystem::directory_iterator(_directory))
-            {
-                newFiles.insert(entry.path().string());
-            }
+            RecursiveScanDirectory(_directory, newFiles);
 
             for (const auto& file : newFiles)
             {
@@ -50,6 +44,28 @@ void ResourceManager::StartPeriodicCheck() {
             _currentFiles = newFiles;
         }
     }).detach();
+};
+
+void ResourceManager::RecursiveScanDirectory(const std::filesystem::path& directory, std::set<std::string>& files) const {
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(directory))
+    {
+        if (std::filesystem::is_regular_file(entry))
+        {
+            files.insert(entry.path().string());
+        }
+    }
+};
+
+const std::string ResourceManager::findResourceInPaths(const std::string& resourceName)
+{
+    for (const std::string& filePath : _currentFiles)
+    {
+        if (filePath.find(resourceName) != std::string::npos)
+        {
+            return filePath;
+        }
+    }
+    return "";
 };
 
 ResourceManager* ResourceManager::GetInstance(const std::string& dir)

--- a/game/managers/resource_manager.hpp
+++ b/game/managers/resource_manager.hpp
@@ -12,12 +12,14 @@ namespace game {
 
                 // Directory tracking
                 std::set<std::string> _currentFiles;
-                std::string _directory;
+                std::filesystem::path _directory;
                 std::map<std::string, std::any> _storage;
 
                 ResourceManager(const std::string& dir);
                 void UpdateFileList();
                 void StartPeriodicCheck();
+                void RecursiveScanDirectory(const std::filesystem::path& directory, std::set<std::string>& files) const;
+                const std::string findResourceInPaths(const std::string& resourceName);
 
             public:
                 // Singleton get instance method
@@ -27,35 +29,35 @@ namespace game {
                 template <typename T>
                 T* GetResource(const std::string& resourceName)
                 {
-                    std::cout << "Trying to get the " << resourceName << " resource" << std::endl;
+                    std::string pathInFiles = findResourceInPaths(resourceName);
 
-                    if (_currentFiles.find(resourceName) == _currentFiles.end())
+                    if (pathInFiles.empty())
                     {
                         return nullptr;    
                     }
 
-                    if (_storage.find(resourceName) != _storage.end())
+                    if (_storage.find(pathInFiles) != _storage.end())
                     {
-                        return std::any_cast<T*>(_storage[resourceName]);
+                        return std::any_cast<T*>(_storage[pathInFiles]);
                     }
 
                     T* resource = nullptr;
 
                     if constexpr (std::is_same_v<T, raylib::Texture2D>)
                     {
-                        resource = new raylib::Texture2D(resourceName);//LoadTexture2D(resourceName);
+                        resource = new raylib::Texture2D(pathInFiles);
                     }
                     else if constexpr (std::is_same_v<T, int>)
                     {
-                        //resource = LoadSound(resourceName);
+                        //resource = LoadSound(pathInFiles);
                     }
                     else if constexpr (std::is_same_v<T, std::string>)
                     {
-                        //resource = LoadImage(resourceName);
+                        //resource = LoadImage(pathInFiles);
                     }
 
                     if (resource) {
-                        _storage[resourceName] = resource;
+                        _storage[pathInFiles] = resource;
                     }
 
                     return resource;

--- a/game/scenes/char_creation_scene.cpp
+++ b/game/scenes/char_creation_scene.cpp
@@ -8,7 +8,7 @@ CharCreationScene::CharCreationScene()
 
     button = std::make_shared<core::gui::PushButton>("CHARACTER CREATION SCREEN");
     //_image = std::make_shared<core::gui::CImage>("/../game/resources/avatars/characters/00_avatar.png", raylib::Vector2(GetScreenWidth()/2 - 50,GetScreenHeight()/2 - 140), raylib::Vector2(100,100));
-    _image = std::make_shared<core::gui::CImage>(_resource->GetResource<raylib::Texture2D>("avatars/characters/00_avatar.png"), raylib::Vector2(GetScreenWidth()/2 - 50,GetScreenHeight()/2 - 140), raylib::Vector2(100,100));
+    _image = std::make_shared<core::gui::CImage>(_resource->GetResource<raylib::Texture2D>("00_avatar.png"), raylib::Vector2(GetScreenWidth()/2.0f - 50,GetScreenHeight()/2.0f - 140), raylib::Vector2(100,100));
     _scene = nullptr;
 };
 


### PR DESCRIPTION
Multiple problems found:
 - path with `\` not correct on windows with `//` <- this has to be fixed sometime to be platform independent
 - resource manager was checking only the root directory, not recursively adding all the files from all the directories in the root resource directory
 - passing a pointer then making in shared will de-allocate the texture; temporary (or permanently 😸 )go back to raw pointers.